### PR TITLE
XIVY-2938 Deprecate old CronByGlobalVariableTriggerStartEventBean

### DIFF
--- a/cronjob-demo/pom.xml
+++ b/cronjob-demo/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.cronjob</groupId>
   <artifactId>cronjob-demo</artifactId>
-  <version>10.0.5-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>iar</packaging>
   <dependencies>
     <dependency>
@@ -14,12 +14,22 @@
       <type>iar</type>
     </dependency>
   </dependencies>
+  <pluginRepositories>
+    <!-- Snapshot releases are available via sonatype.org -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>  
   <build>
     <plugins>
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>11.2.0-SNAPSHOT</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/cronjob-product/pom.xml
+++ b/cronjob-product/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.cronjob</groupId>
   <artifactId>cronjob-product</artifactId>
-  <version>10.0.5-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <build>

--- a/cronjob-test/pom.xml
+++ b/cronjob-test/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.cronjob</groupId>
   <artifactId>cronjob-test</artifactId>
-  <version>10.0.5-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>iar-integration-test</packaging>
   <dependencies>
     <dependency>
@@ -20,13 +20,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <pluginRepositories>
+    <!-- Snapshot releases are available via sonatype.org -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>  
   <build>
     <testSourceDirectory>src_test</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>11.2.0-SNAPSHOT</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/cronjob/pom.xml
+++ b/cronjob/pom.xml
@@ -4,8 +4,11 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.axonivy.utils.cronjob</groupId>
   <artifactId>cronjob</artifactId>
-  <version>10.0.5-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <organization>
+    <name>Axon Ivy AG</name>
+  </organization>
   <properties>
     <quartz.version>2.3.2</quartz.version>
   </properties>
@@ -22,12 +25,22 @@
       </exclusions>
     </dependency>
   </dependencies>
+  <pluginRepositories>
+    <!-- Snapshot releases are available via sonatype.org -->
+    <pluginRepository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>  
   <build>
     <plugins>
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.6</version>
+        <version>11.2.0-SNAPSHOT</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/cronjob/src/com/axonivy/utils/cronjob/CronByGlobalVariableTriggerStartEventBean.java
+++ b/cronjob/src/com/axonivy/utils/cronjob/CronByGlobalVariableTriggerStartEventBean.java
@@ -22,6 +22,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import ch.ivyteam.ivy.persistence.PersistencyException;
 import ch.ivyteam.ivy.process.eventstart.AbstractProcessStartEventBean;
 import ch.ivyteam.ivy.process.eventstart.IProcessStartEventBeanRuntime;
+import ch.ivyteam.ivy.process.eventstart.beans.TimerBean;
 import ch.ivyteam.ivy.process.extension.ui.ExtensionUiBuilder;
 import ch.ivyteam.ivy.process.extension.ui.IUiFieldEditor;
 import ch.ivyteam.ivy.process.extension.ui.UiEditorExtension;
@@ -35,7 +36,9 @@ import ch.ivyteam.log.Logger;
  * Configuration string and will schedule by using the expression
  *
  * The Quartz framework is used as underlying scheduler framework.
+ * @deprecated use {@link TimerBean} instead
  */
+@Deprecated(since="11.2")
 public class CronByGlobalVariableTriggerStartEventBean extends AbstractProcessStartEventBean implements Job {
 	private Scheduler scheduler = null;
 	private JobDetail job = null;

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.axonivy.utils.cronjob</groupId>
   <name>cronjob</name>
   <artifactId>cronjob-modules</artifactId>
-  <version>10.0.5-SNAPSHOT</version>
+  <version>11.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>
@@ -17,7 +17,7 @@
     <developerConnection>scm:git:https://github.com/axonivy-market/${project.name}.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-
+  
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
Deprecate old CronByGlobalVariableTriggerStartEventBean. Instead use new TimerBean introduced with Axon Ivy 11.2